### PR TITLE
Changes to the metadata query gathering for spark

### DIFF
--- a/dbt/include/spark/macros/adapters.sql
+++ b/dbt/include/spark/macros/adapters.sql
@@ -141,12 +141,20 @@
   {% do return(load_result('get_columns_in_relation').table) %}
 {% endmacro %}
 
-{% macro spark__list_relations_without_caching(relation) %}
-  {% call statement('list_relations_without_caching', fetch_result=True) -%}
-    show table extended in {{ relation }} like '*'
+{% macro spark__list_tables_without_caching(relation) %}
+  {% call statement('list_tables_without_caching', fetch_result=True) -%}
+    show tables in {{ relation.schema }}
   {% endcall %}
 
-  {% do return(load_result('list_relations_without_caching').table) %}
+  {% do return(load_result('list_tables_without_caching').table) %}
+{% endmacro %}
+
+{% macro spark__list_views_without_caching(relation) %}
+  {% call statement('list_views_without_caching', fetch_result=True) -%}
+    show views in {{ relation.schema }}
+  {% endcall %}
+
+  {% do return(load_result('list_views_without_caching').table) %}
 {% endmacro %}
 
 {% macro spark__list_schemas(database) -%}


### PR DESCRIPTION
  * significant improvement for our implementation of individual DBT models farmed out to their own airflow task
  * show tables in <schema> & show views in <schema> vs show table extended in <schema> like '*'
  * describe extended is called on every "ref" inside the model/sql file being run
    * which again is significantly better for our implementation

resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!--- Describe the Pull Request here -->

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.