### PR TITLE
Adjusting setup.py to reflect Slickdeals package and authors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,10 +51,10 @@ def _get_dbt_core_version():
     return f"{minor}{pre}"
 
 
-package_name = "dbt-spark"
-package_version = "1.0.0"
+package_name = "slickdeals-dbt-spark"
+package_version = "1.0.1"
 dbt_core_version = _get_dbt_core_version()
-description = """The Apache Spark adapter plugin for dbt"""
+description = """The Apache Spark adapter plugin for dbt, slickdeals flavor"""
 
 odbc_extras = ['pyodbc>=4.0.30']
 pyhive_extras = [
@@ -71,9 +71,9 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
 
-    author='dbt Labs',
-    author_email='info@dbtlabs.com',
-    url='https://github.com/dbt-labs/dbt-spark',
+    author='Slickdeals',
+    author_email='ryan.clift@slickdeals.net',
+    url='https://github.com/ryanClift-sd/dbt-spark',
 
     packages=find_namespace_packages(include=['dbt', 'dbt.*']),
     include_package_data=True,


### PR DESCRIPTION
changes to authors to remove "dbt labs", though they are the core authors, guess this package and wheel should reflect we are now the "authors"?  Ensures that the package-name variable is also matching against when I built the wheel etc so that way future builds have the proper name

resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!--- Describe the Pull Request here -->

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-spark next" section.